### PR TITLE
予定開始日より早くに完了したチケットの状態が完了にならない不具合を修正

### DIFF
--- a/PainlessGantt/InputCompletion.cs
+++ b/PainlessGantt/InputCompletion.cs
@@ -121,7 +121,7 @@ namespace PainlessGantt
                     return;
                 if (ticket.EstimatedPeriod.Start == default || ticket.EstimatedPeriod.End == default)
                     return;
-                if (DateTime.Today < ticket.EstimatedPeriod.Start)
+                if (DateTime.Today < ticket.EstimatedPeriod.Start && (ticket.ActualPeriod.Start == default || ticket.ActualPeriod.End == default))
                     return;
 
                 if (ticket.ActualPeriod.Start != default && ticket.ActualPeriod.End != default)


### PR DESCRIPTION
```yaml
プロジェクト一覧:
- プロジェクト: P001
  作業一覧:
  - 作業: T001
    予定: { 開始: 2018/06/01, 終了: 2018/06/02 }
    実績: { 開始: 2018/05/01, 終了: 2018/05/02 }
```